### PR TITLE
feat: add join trees without key

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ defined for a single instance of the tree. All exposed methods depend on the
 
 - The implementation has some basic operations of an `AvlTree` (which canonically is also a `Set`) and separate (planned) implementations for:
   1. Joining 2 AvlTrees via a mutually exclusive key ✅
-  2. Joining 2 AvlTree without key ❌
+  2. Joining 2 AvlTrees without key ✅
   3. Split an AvlTree via key ✅
   4. SplitLast ✅
   5. Insert via Split ❌

--- a/lib/src/avl_tree/avl_tree_utils.dart
+++ b/lib/src/avl_tree/avl_tree_utils.dart
@@ -395,6 +395,31 @@ bool _isWithinBound<T>(
   return checkLowerBound ? comparison < 0 : comparison > 0;
 }
 
+final class JoinError extends Error {
+  JoinError(this.key, this.lowerBound, this.upperBound);
+
+  final String? key;
+
+  final String lowerBound;
+
+  final String upperBound;
+
+  String _genBody() {
+    if (key == null) {
+      return 'The lowerbound of "$lowerBound" must be less than the upperbound'
+          ' of "$upperBound"';
+    }
+
+    return 'The key "$key" must be greater than "$lowerBound" and less than'
+        ' "$upperBound" based on the comparator provided';
+  }
+
+  @override
+  String toString() {
+    return 'Cannot join 2 overlapping trees. ${_genBody()}';
+  }
+}
+
 /// Throws a [JoinError] if [lowerBound] is greater than [key] or if
 /// [upperBound] is less than [key]
 void _throwOnOverlap<T>({
@@ -417,7 +442,7 @@ void _throwOnOverlap<T>({
           comparator: comparator,
           key: key ?? lowerBound)) {
     throw JoinError(
-      key.toString(),
+      key?.toString(),
       lowerBound?.toString() ?? '',
       upperBound?.toString() ?? '',
     );

--- a/lib/src/avl_tree/avl_tree_utils.dart
+++ b/lib/src/avl_tree/avl_tree_utils.dart
@@ -378,3 +378,48 @@ _AvlNode<T> _nodeAtRoot<T>(_AvlNode<T> node) {
 
   return current;
 }
+
+/// Checks if a value overlaps with a key such that:
+///   - If [checkLowerBound] is `true`, then [value] must be null or less than
+///     [key] if not null.
+///   - If [checkLowerBound] is `false, then [value] must be null or greater
+///     than [key] if not null.
+bool _isWithinBound<T>(
+  T? value, {
+  required bool checkLowerBound,
+  required T? key,
+  required BinaryCompare<T, T> comparator,
+}) {
+  if (value == null || key == null) return true;
+  final comparison = comparator(value, key);
+  return checkLowerBound ? comparison < 0 : comparison > 0;
+}
+
+/// Throws a [JoinError] if [lowerBound] is greater than [key] or if
+/// [upperBound] is less than [key]
+void _throwOnOverlap<T>({
+  required T? lowerBound,
+  required T? upperBound,
+  required BinaryCompare<T, T> comparator,
+  required T? key,
+}) {
+  /// Highest value in [lower] must less than [key] and [lowest] value in
+  /// [upper] must be greater than [key].
+  ///
+  ///   - Fallback to [upper] tree's lowest value if key is null
+  ///   - Fallback to [lower] tree's highest value if key is null
+  if (!_isWithinBound(lowerBound,
+          checkLowerBound: true,
+          comparator: comparator,
+          key: key ?? upperBound) &&
+      !_isWithinBound(upperBound,
+          checkLowerBound: false,
+          comparator: comparator,
+          key: key ?? lowerBound)) {
+    throw JoinError(
+      key.toString(),
+      lowerBound?.toString() ?? '',
+      upperBound?.toString() ?? '',
+    );
+  }
+}

--- a/lib/src/avl_tree/join_avl_trees.dart
+++ b/lib/src/avl_tree/join_avl_trees.dart
@@ -3,7 +3,7 @@ part of 'avl_tree.dart';
 /// Performs a `join` operation on 2 sorted trees (sets), that is `AvlTree`s
 /// [lower] and [upper] resulting in an entirely new `AvlTree`.
 ///
-/// If:
+/// If the [key] is not `null`:
 ///   - Height of [lower] is greater than height of [upper] + 1 then [upper]
 ///     joins [lower] in the `right-most` child whose height is less than or
 ///     equal to height of [upper] + 1.
@@ -12,6 +12,9 @@ part of 'avl_tree.dart';
 ///     equal to height of [lower] + 1.
 ///   - None of the above are satisfied, a new [AvlTree] is formed by joining
 ///     [lower] and [upper] with [key] as the root.
+///
+/// If the [key] is null, they are joined via the highest value in the
+/// [lower] `AvlTree` which acts as the [key].
 ///
 /// It is imperative that values in [lower] and [upper] do not overlap with the
 /// key such that, `highest value` in [lower] `<` [key] `&&` `lowest value` in
@@ -33,8 +36,8 @@ AvlTree<T> joinTrees<T>({
 
   // No overlaps for joins!
   _throwOnOverlap(
-    lowerBound: lower.highest,
-    upperBound: upper.lowest,
+    lowerBound: lowerBound,
+    upperBound: upperBound,
     comparator: comparator,
     key: key,
   );
@@ -358,6 +361,11 @@ _AvlNode<T>? _joinWithoutKey<T>({
   if (left == null) return right;
 
   // Get largest value and join with current node on right
-  final (largest, key) = _splitLast(left, comparator);
-  return _join(left: largest, key: key, right: right, comparator: comparator);
+  final (leftOnRight, key) = _splitLast(left, comparator);
+  return _join(
+    left: leftOnRight,
+    key: key,
+    right: right,
+    comparator: comparator,
+  );
 }

--- a/lib/src/avl_tree/join_avl_trees.dart
+++ b/lib/src/avl_tree/join_avl_trees.dart
@@ -43,25 +43,13 @@ final class JoinError extends Error {
 AvlTree<T> joinTrees<T>(AvlTree<T> lower, T key, AvlTree<T> upper) {
   final comparator = lower.comparator;
 
-  bool isWithinBound(T? value, {required bool checkLowerBound}) {
-    if (value == null) return true;
-    final comparison = comparator(value, key);
-    return checkLowerBound ? comparison < 0 : comparison > 0;
-  }
-
-  final lBound = lower.highest;
-  final uBound = upper.lowest;
-
-  /// Highest value in [lower] must less than [key] and [lowest] value in
-  /// [upper] must be greater than [key]
-  if (!isWithinBound(lBound, checkLowerBound: true) &&
-      !isWithinBound(uBound, checkLowerBound: false)) {
-    throw JoinError(
-      key.toString(),
-      lBound?.toString() ?? '',
-      uBound?.toString() ?? '',
-    );
-  }
+  // No overlaps for joins!
+  _throwOnOverlap(
+    lowerBound: lower.highest,
+    upperBound: upper.lowest,
+    comparator: comparator,
+    key: key,
+  );
 
   return AvlTree._(
     _join(

--- a/lib/src/avl_tree/join_avl_trees.dart
+++ b/lib/src/avl_tree/join_avl_trees.dart
@@ -1,22 +1,5 @@
 part of 'avl_tree.dart';
 
-final class JoinError extends Error {
-  JoinError(this.key, this.lowerBound, this.upperBound);
-
-  final String key;
-
-  final String lowerBound;
-
-  final String upperBound;
-
-  @override
-  String toString() {
-    return 'Cannot join 2 overlapping trees.'
-        'The key "$key" must be greater than "$lowerBound" and lower than'
-        ' "$upperBound" based on the comparator provided';
-  }
-}
-
 /// Performs a `join` operation on 2 sorted trees (sets), that is `AvlTree`s
 /// [lower] and [upper] resulting in an entirely new `AvlTree`.
 ///

--- a/test/avl_tree/join_avl_trees_test.dart
+++ b/test/avl_tree/join_avl_trees_test.dart
@@ -18,104 +18,141 @@ void main() {
     joinTree.clear();
   });
 
-  test('Two empty trees at root', () {
-    final joined = joinTrees(baseTree, 0, joinTree);
+  group('Join with key', () {
+    test('Two empty trees at root', () {
+      final joined = joinTrees(lower: baseTree, key: 0, upper: joinTree);
 
-    check(joined.length).equals(1);
-    check(joined.root).equals(0);
-    check(joined.ordered()).deepEquals({0});
-  });
+      check(joined.length).equals(1);
+      check(joined.root).equals(0);
+      check(joined.ordered()).deepEquals({0});
+    });
 
-  test('adds right node to right subtree of left node and rotates', () {
-    insertAll([6, 4, 9, 8, 12], tree: baseTree);
-    insertAll([16], tree: joinTree);
+    test('adds right node to right subtree of left node and rotates', () {
+      insertAll([6, 4, 9, 8, 12], tree: baseTree);
+      insertAll([16], tree: joinTree);
 
-    final joined = joinTrees(baseTree, 15, joinTree);
+      final joined = joinTrees(lower: baseTree, key: 15, upper: joinTree);
 
-    check(
-      joined.ordered(transversal: Transversal.preOrder),
-    ).deepEquals(
-      {9, 6, 4, 8, 15, 12, 16},
-    );
-  });
-
-  test('adds right node to right subtree of left node with no rotations', () {
-    insertAll([6, 4, 2, 9], tree: baseTree);
-    insertAll([16], tree: joinTree);
-
-    final joined = joinTrees(baseTree, 15, joinTree);
-
-    check(
-      joined.ordered(transversal: Transversal.preOrder),
-    ).deepEquals(
-      {6, 4, 2, 15, 9, 16},
-    );
-  });
-
-  test('adds right node to right subtree of left node after search', () {
-    insertAll([6, 4, 9, 2, 8, 12, 7], tree: baseTree);
-    insertAll([16], tree: joinTree);
-
-    final joined = joinTrees(baseTree, 15, joinTree);
-
-    check(
-      joined.ordered(transversal: Transversal.preOrder),
-    ).deepEquals(
-      {6, 4, 2, 9, 8, 7, 15, 12, 16},
-    );
-  });
-
-  test('adds left node to left subtree of right node with no rotations', () {
-    insertAll([6], tree: baseTree);
-    insertAll([12, 10, 15, 14, 18], tree: joinTree);
-
-    final joined = joinTrees(baseTree, 7, joinTree);
-
-    check(
-      joined.ordered(transversal: Transversal.preOrder),
-    ).deepEquals(
-      {12, 7, 6, 10, 15, 14, 18},
-    );
-  });
-
-  test('adds left node to left subtree of right node and rotates', () {
-    insertAll([6], tree: baseTree);
-    insertAll([12, 10, 15, 9], tree: joinTree);
-
-    final joined = joinTrees(baseTree, 7, joinTree);
-
-    check(
-      joined.ordered(transversal: Transversal.preOrder),
-    ).deepEquals(
-      {9, 7, 6, 12, 10, 15},
-    );
-  });
-
-  test('adds left node to left subtree of right node after search', () {
-    insertAll([2], tree: baseTree);
-    insertAll([12, 10, 15, 8, 17, 11, 9], tree: joinTree);
-
-    final joined = joinTrees(baseTree, 3, joinTree);
-
-    check(
-      joined.ordered(transversal: Transversal.preOrder),
-    ).deepEquals(
-      {12, 8, 3, 2, 10, 9, 11, 15, 17},
-    );
-  });
-
-  test('throws a join error when values overlap', () {
-    insertAll([2, 10], tree: baseTree);
-    insertAll([7], tree: joinTree);
-
-    check(() => joinTrees(baseTree, 8, joinTree)).throws<JoinError>()
-      ..has((erro) => erro.key, 'key').equals('8')
-      ..has((err) => err.lowerBound, 'lowerbound').equals('10')
-      ..has((err) => err.upperBound, 'upperbound').equals('7')
-      ..has((err) => err.toString(), 'toString').equals(
-        'Cannot join 2 overlapping trees.'
-        'The key "8" must be greater than "10" and lower than'
-        ' "7" based on the comparator provided',
+      check(
+        joined.ordered(transversal: Transversal.preOrder),
+      ).deepEquals(
+        {9, 6, 4, 8, 15, 12, 16},
       );
+    });
+
+    test('adds right node to right subtree of left node with no rotations', () {
+      insertAll([6, 4, 2, 9], tree: baseTree);
+      insertAll([16], tree: joinTree);
+
+      final joined = joinTrees(lower: baseTree, key: 15, upper: joinTree);
+
+      check(
+        joined.ordered(transversal: Transversal.preOrder),
+      ).deepEquals(
+        {6, 4, 2, 15, 9, 16},
+      );
+    });
+
+    test('adds right node to right subtree of left node after search', () {
+      insertAll([6, 4, 9, 2, 8, 12, 7], tree: baseTree);
+      insertAll([16], tree: joinTree);
+
+      final joined = joinTrees(lower: baseTree, key: 15, upper: joinTree);
+
+      check(
+        joined.ordered(transversal: Transversal.preOrder),
+      ).deepEquals(
+        {6, 4, 2, 9, 8, 7, 15, 12, 16},
+      );
+    });
+
+    test('adds left node to left subtree of right node with no rotations', () {
+      insertAll([6], tree: baseTree);
+      insertAll([12, 10, 15, 14, 18], tree: joinTree);
+
+      final joined = joinTrees(lower: baseTree, key: 7, upper: joinTree);
+
+      check(
+        joined.ordered(transversal: Transversal.preOrder),
+      ).deepEquals(
+        {12, 7, 6, 10, 15, 14, 18},
+      );
+    });
+
+    test('adds left node to left subtree of right node and rotates', () {
+      insertAll([6], tree: baseTree);
+      insertAll([12, 10, 15, 9], tree: joinTree);
+
+      final joined = joinTrees(lower: baseTree, key: 7, upper: joinTree);
+
+      check(
+        joined.ordered(transversal: Transversal.preOrder),
+      ).deepEquals(
+        {9, 7, 6, 12, 10, 15},
+      );
+    });
+
+    test('adds left node to left subtree of right node after search', () {
+      insertAll([2], tree: baseTree);
+      insertAll([12, 10, 15, 8, 17, 11, 9], tree: joinTree);
+
+      final joined = joinTrees(lower: baseTree, key: 3, upper: joinTree);
+
+      check(
+        joined.ordered(transversal: Transversal.preOrder),
+      ).deepEquals(
+        {12, 8, 3, 2, 10, 9, 11, 15, 17},
+      );
+    });
+  });
+
+  group('Join without key', () {
+    test('joins 2 tree without a key', () {
+      insertAll([10, 6, 16, 2, 12, 9, 18], tree: baseTree);
+      insertAll([30, 24, 36, 22, 32, 26, 38], tree: joinTree);
+
+      check(
+        joinTrees<int>(lower: baseTree, key: null, upper: joinTree).ordered(
+          transversal: Transversal.preOrder,
+        ),
+      ).deepEquals({18, 10, 6, 2, 9, 16, 12, 30, 24, 22, 26, 36, 32, 38});
+    });
+  });
+
+  group('Throws Error', () {
+    test('throws a join error when values overlap with key', () {
+      insertAll([2, 10], tree: baseTree);
+      insertAll([7], tree: joinTree);
+
+      check(() => joinTrees(lower: baseTree, key: 8, upper: joinTree))
+          .throws<JoinError>()
+        ..has((erro) => erro.key, 'key').equals('8')
+        ..has((err) => err.lowerBound, 'lowerbound').equals('10')
+        ..has((err) => err.upperBound, 'upperbound').equals('7')
+        ..has((err) => err.toString(), 'toString').equals(
+          'Cannot join 2 overlapping trees.'
+          ' The key "8" must be greater than "10" and lower than'
+          ' "7" based on the comparator provided',
+        );
+    });
+
+    test(
+      'throws a join error when values in two trees overlap without key',
+      () {
+        insertAll([2, 10], tree: baseTree);
+        insertAll([7], tree: joinTree);
+
+        check(() => joinTrees<int>(lower: baseTree, key: null, upper: joinTree))
+            .throws<JoinError>()
+          ..has((erro) => erro.key, 'key').isNull()
+          ..has((err) => err.lowerBound, 'lowerbound').equals('10')
+          ..has((err) => err.upperBound, 'upperbound').equals('7')
+          ..has((err) => err.toString(), 'toString').equals(
+            'Cannot join 2 overlapping trees. '
+            'The lowerbound of "10" must be less than the upperbound'
+            ' of "7"',
+          );
+      },
+    );
   });
 }


### PR DESCRIPTION
This PR:

- Tweaks existing `joinTrees` code to include ability to join 2 trees without a key